### PR TITLE
Features/94 add sample unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /starter-kit/app/build
 /starter-kit/posts-api/build
 /starter-kit/tasks-api/dist
+/starter-kit/tasks-api/coverage
 
 # misc
 .DS_Store

--- a/starter-kit/tasks-api/src/tasks/task.repository.spec.ts
+++ b/starter-kit/tasks-api/src/tasks/task.repository.spec.ts
@@ -12,7 +12,7 @@ const mockQueryBuilder = () => ({
 });
 
 const mockTaskEntity = () => ({
-    save: jest.fn(),
+  save: jest.fn(),
 });
 
 describe('TaskRepository', () => {
@@ -30,15 +30,17 @@ describe('TaskRepository', () => {
     }).compile();
 
     taskRepository = await module.get<TaskRepository>(TaskRepository);
-    queryBuilder = await module.get<SelectQueryBuilder<Task>>(SelectQueryBuilder);
+    queryBuilder = await module.get<SelectQueryBuilder<Task>>(
+      SelectQueryBuilder,
+    );
     taskEntity = await module.get<Task>(Task);
   });
 
   describe('getTasks', () => {
     it('calls createQueryBuilder and gets all tasks from the repository', async () => {
       taskRepository.createQueryBuilder = jest.fn().mockReturnValue(queryBuilder);
-      queryBuilder.andWhere = jest.fn().mockReturnValue('mockStatus/Search');
-      queryBuilder.getMany = jest.fn().mockReturnValue('mockTasks');
+      queryBuilder.andWhere.mockReturnValue('mockStatus/Search');
+      queryBuilder.getMany.mockReturnValue('mockTasks');
       expect(taskRepository.createQueryBuilder).not.toHaveBeenCalled();
       expect(queryBuilder.andWhere).not.toHaveBeenCalled();
       expect(queryBuilder.getMany).not.toHaveBeenCalled();
@@ -62,28 +64,38 @@ describe('TaskRepository', () => {
   });
 
   describe('createTask', () => {
-    it('creates a new Task entity with the info passed from CreateTaskDTO', async () => { 
-        taskEntity.save.mockResolvedValue(undefined);
-        taskRepository.create = jest.fn().mockReturnValue(taskEntity);
-        expect(taskEntity.save).not.toHaveBeenCalled();
-        expect(taskRepository.create).not.toHaveBeenCalled();
+    it('creates a new Task entity with the info passed from CreateTaskDTO', async () => {
+      taskEntity.save.mockResolvedValue(undefined);
+      taskRepository.create = jest.fn().mockReturnValue(taskEntity);
+      expect(taskEntity.save).not.toHaveBeenCalled();
+      expect(taskRepository.create).not.toHaveBeenCalled();
 
-        const createDTO: CreateTask = {
-            title: 'Test Task',
-            description: 'Test Desc'
-        }
-        const result = taskRepository.createTask(createDTO);
-        expect(taskEntity.save).toHaveBeenCalled();
-        expect(taskRepository.create).toHaveBeenCalled();
-        expect(result).resolves;
+      const createDTO: CreateTask = {
+        title: 'Test Task',
+        description: 'Test Desc',
+      };
+      const result = taskRepository.createTask(createDTO);
+      expect(taskEntity.save).toHaveBeenCalled();
+      expect(taskRepository.create).toHaveBeenCalled();
+      expect(result).resolves;
     });
   });
 
   describe('updateTaskStatus', () => {
     it('calls findOne() to update the status of a task', async () => {
-        taskEntity.save.mockResolvedValue(undefined);
-        taskRepository.findOne.mockResolvedValue('mockTask');
-        expect(taskRepository.findOne).not.toHaveBeenCalled();
+      taskRepository.findOne = jest.fn().mockResolvedValue({
+        id: 1,
+        status: TaskStatus.OPEN,
+        save: taskEntity.save,
+      });
+      taskEntity.save.mockResolvedValue(undefined);
+      expect(taskRepository.findOne).not.toHaveBeenCalled();
+      expect(taskEntity.save).not.toHaveBeenCalled();
+
+      const result = await taskRepository.updateTaskStatus(1, TaskStatus.DONE);
+      expect(taskRepository.findOne).toHaveBeenCalledWith(1);
+      expect(taskEntity.save).toHaveBeenCalled();
+      expect(result.status).toEqual(TaskStatus.DONE);
     });
   });
 });

--- a/starter-kit/tasks-api/src/tasks/task.repository.spec.ts
+++ b/starter-kit/tasks-api/src/tasks/task.repository.spec.ts
@@ -1,0 +1,89 @@
+import { Test } from '@nestjs/testing';
+import { TaskRepository } from './task.repository';
+import { Task } from './task.entity';
+import { TaskStatus } from './task-status.enum';
+import { CreateTask } from './dto/create-task.dto';
+import { TaskFilter } from './dto/task-filter.dto';
+import { SelectQueryBuilder } from 'typeorm';
+
+const mockQueryBuilder = () => ({
+  andWhere: jest.fn(),
+  getMany: jest.fn(),
+});
+
+const mockTaskEntity = () => ({
+    save: jest.fn(),
+});
+
+describe('TaskRepository', () => {
+  let taskRepository;
+  let queryBuilder;
+  let taskEntity;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        TaskRepository,
+        { provide: SelectQueryBuilder, useFactory: mockQueryBuilder },
+        { provide: Task, useFactory: mockTaskEntity },
+      ],
+    }).compile();
+
+    taskRepository = await module.get<TaskRepository>(TaskRepository);
+    queryBuilder = await module.get<SelectQueryBuilder<Task>>(SelectQueryBuilder);
+    taskEntity = await module.get<Task>(Task);
+  });
+
+  describe('getTasks', () => {
+    it('calls createQueryBuilder and gets all tasks from the repository', async () => {
+      taskRepository.createQueryBuilder = jest.fn().mockReturnValue(queryBuilder);
+      queryBuilder.andWhere = jest.fn().mockReturnValue('mockStatus/Search');
+      queryBuilder.getMany = jest.fn().mockReturnValue('mockTasks');
+      expect(taskRepository.createQueryBuilder).not.toHaveBeenCalled();
+      expect(queryBuilder.andWhere).not.toHaveBeenCalled();
+      expect(queryBuilder.getMany).not.toHaveBeenCalled();
+
+      const filters: TaskFilter = {
+        status: TaskStatus.IN_PROGRESS,
+        search: 'Some search query',
+      };
+      const result = await taskRepository.getTasks(filters);
+
+      expect(taskRepository.createQueryBuilder).toHaveBeenCalledWith('task');
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(expect.any(String), {
+        status: TaskStatus.IN_PROGRESS,
+      });
+      expect(queryBuilder.andWhere).toHaveBeenCalledWith(expect.any(String), {
+        search: '%Some search query%',
+      });
+      expect(queryBuilder.getMany).toHaveBeenCalled();
+      expect(result).toEqual('mockTasks');
+    });
+  });
+
+  describe('createTask', () => {
+    it('creates a new Task entity with the info passed from CreateTaskDTO', async () => { 
+        taskEntity.save.mockResolvedValue(undefined);
+        taskRepository.create = jest.fn().mockReturnValue(taskEntity);
+        expect(taskEntity.save).not.toHaveBeenCalled();
+        expect(taskRepository.create).not.toHaveBeenCalled();
+
+        const createDTO: CreateTask = {
+            title: 'Test Task',
+            description: 'Test Desc'
+        }
+        const result = taskRepository.createTask(createDTO);
+        expect(taskEntity.save).toHaveBeenCalled();
+        expect(taskRepository.create).toHaveBeenCalled();
+        expect(result).resolves;
+    });
+  });
+
+  describe('updateTaskStatus', () => {
+    it('calls findOne() to update the status of a task', async () => {
+        taskEntity.save.mockResolvedValue(undefined);
+        taskRepository.findOne.mockResolvedValue('mockTask');
+        expect(taskRepository.findOne).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/starter-kit/tasks-api/src/tasks/task.repository.ts
+++ b/starter-kit/tasks-api/src/tasks/task.repository.ts
@@ -27,10 +27,11 @@ export class TaskRepository extends Repository<Task> {
   async createTask(createTaskDTO: CreateTask): Promise<Task> {
     const { title, description } = createTaskDTO;
     
-    const task = new Task();
+    const task = this.create();
     task.title = title;
     task.description = description;
     task.status = TaskStatus.OPEN;
+    
     await task.save();
 
     return task;

--- a/starter-kit/tasks-api/src/tasks/tasks.service.spec.ts
+++ b/starter-kit/tasks-api/src/tasks/tasks.service.spec.ts
@@ -4,6 +4,7 @@ import { TaskRepository } from './task.repository';
 import { TaskStatus } from './task-status.enum';
 import { NotFoundException } from '@nestjs/common';
 import { TaskFilter } from './dto/task-filter.dto';
+import { CreateTask } from './dto/create-task.dto';
 
 const mockTaskRepository = () => ({
   getTasks: jest.fn(),
@@ -67,7 +68,10 @@ describe('TasksService', () => {
       taskRepository.createTask.mockResolvedValue('mockTask');
       expect(taskRepository.createTask).not.toHaveBeenCalled();
 
-      const createTaskDto = { title: 'Test Task', description: 'Test Desc' };
+      const createTaskDto: CreateTask = {
+        title: 'Test Task',
+        description: 'Test Desc',
+      };
       const result = await tasksService.createTask(createTaskDto);
 
       expect(taskRepository.createTask).toHaveBeenCalledWith(createTaskDto);
@@ -84,7 +88,10 @@ describe('TasksService', () => {
       expect(taskRepository.updateTaskStatus).not.toHaveBeenCalled();
 
       const result = await tasksService.updateTaskStatus(1, TaskStatus.DONE);
-      expect(taskRepository.updateTaskStatus).toHaveBeenCalledWith( 1, TaskStatus.DONE);
+      expect(taskRepository.updateTaskStatus).toHaveBeenCalledWith(
+        1,
+        TaskStatus.DONE,
+      );
       expect(result.status).toEqual(TaskStatus.DONE);
     });
   });

--- a/starter-kit/tasks-api/src/tasks/tasks.service.spec.ts
+++ b/starter-kit/tasks-api/src/tasks/tasks.service.spec.ts
@@ -64,7 +64,7 @@ describe('TasksService', () => {
   });
 
   describe('createTask', () => {
-    it('calls taskRepository.createTask() and returns the result', async () => {
+    it('calls taskRepository.createTask() and returns the newly created task', async () => {
       taskRepository.createTask.mockResolvedValue('mockTask');
       expect(taskRepository.createTask).not.toHaveBeenCalled();
 
@@ -84,7 +84,6 @@ describe('TasksService', () => {
       taskRepository.updateTaskStatus.mockResolvedValue({
         status: TaskStatus.DONE,
       });
-      expect(taskRepository.findOne).not.toHaveBeenCalled();
       expect(taskRepository.updateTaskStatus).not.toHaveBeenCalled();
 
       const result = await tasksService.updateTaskStatus(1, TaskStatus.DONE);

--- a/starter-kit/tasks-api/src/tasks/tasks.service.spec.ts
+++ b/starter-kit/tasks-api/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test } from '@nestjs/testing';
+import { TasksService } from './tasks.service';
+import { TaskRepository } from './task.repository';
+import { TaskStatus } from './task-status.enum';
+import { NotFoundException } from '@nestjs/common';
+import { TaskFilter } from './dto/task-filter.dto';
+
+const mockTaskRepository = () => ({
+  getTasks: jest.fn(),
+  findOne: jest.fn(),
+  createTask: jest.fn(),
+  delete: jest.fn(),
+  updateTaskStatus: jest.fn(),
+});
+
+describe('TasksService', () => {
+  let tasksService;
+  let taskRepository;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        { provide: TaskRepository, useFactory: mockTaskRepository },
+      ],
+    }).compile();
+
+    tasksService = await module.get<TasksService>(TasksService);
+    taskRepository = await module.get<TaskRepository>(TaskRepository);
+  });
+
+  describe('getTasks', () => {
+    it('calls taskRepository.getTasks() and gets all tasks from the repository', async () => {
+      taskRepository.getTasks.mockResolvedValue('mockTask');
+      expect(taskRepository.getTasks).not.toHaveBeenCalled();
+
+      const filters: TaskFilter = {
+        status: TaskStatus.IN_PROGRESS,
+        search: 'Some search query',
+      };
+      const result = await tasksService.getTasks(filters);
+
+      expect(taskRepository.getTasks).toHaveBeenCalled();
+      expect(result).toEqual('mockTask');
+    });
+  });
+
+  describe('getTaskByid', () => {
+    it('calls taskRepository.findOne() and successfully retrieves and returns the task', async () => {
+      taskRepository.findOne.mockResolvedValue('mockTask');
+      expect(taskRepository.findOne).not.toHaveBeenCalled();
+
+      const result = await tasksService.getTaskByid(1);
+
+      expect(taskRepository.findOne).toHaveBeenCalledWith(1);
+      expect(result).toEqual('mockTask');
+    });
+
+    it('throws and error as task is not found', () => {
+      taskRepository.findOne.mockResolvedValue(null);
+      expect(tasksService.getTaskByid(1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createTask', () => {
+    it('calls taskRepository.createTask() and returns the result', async () => {
+      taskRepository.createTask.mockResolvedValue('mockTask');
+      expect(taskRepository.createTask).not.toHaveBeenCalled();
+
+      const createTaskDto = { title: 'Test Task', description: 'Test Desc' };
+      const result = await tasksService.createTask(createTaskDto);
+
+      expect(taskRepository.createTask).toHaveBeenCalledWith(createTaskDto);
+      expect(result).toEqual('mockTask');
+    });
+  });
+
+  describe('updateTaskStatus', () => {
+    it('Calls taskRepository.updateTaskStatus() to update the status', async () => {
+      taskRepository.updateTaskStatus.mockResolvedValue({
+        status: TaskStatus.DONE,
+      });
+      expect(taskRepository.findOne).not.toHaveBeenCalled();
+      expect(taskRepository.updateTaskStatus).not.toHaveBeenCalled();
+
+      const result = await tasksService.updateTaskStatus(1, TaskStatus.DONE);
+      expect(taskRepository.updateTaskStatus).toHaveBeenCalledWith( 1, TaskStatus.DONE);
+      expect(result.status).toEqual(TaskStatus.DONE);
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('Call taskRepository.deleteTask() to delete a task', async () => {
+      taskRepository.delete.mockResolvedValue({ affected: 1 });
+      expect(taskRepository.delete).not.toHaveBeenCalled();
+
+      await tasksService.deleteTask(1);
+      expect(taskRepository.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('throws and error as task is not found', () => {
+      taskRepository.delete.mockResolvedValue({ affected: 0 });
+      return expect(tasksService.deleteTask(1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+});


### PR DESCRIPTION
#### Created unit tests files:
- tasks.service.spec.ts
- task.repository .spec.ts

#### Changed task.repository.ts:

`const task = new Task();` 

to

 `const task = this.create();`

(made it a little easier to test)
 
#### Updated .gitignore:
`/starter-kit/tasks-api/coverage`