### PR TITLE
Code of Conduct file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 We are committed to building a safe, friendly, and harassment-free culture for everyone. We pledge to interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Scope
-This Code of Conduct applies to the [US-EPA-CAMD](https://github.com/US-EPA-CAMD) GitHub organization, its communications, events, and anyone participating in the US-EPA-CAMD GitHub community. Your use of our repositories means you accept and agree to abide by this Code of Conduct, and the [EPA Comment Policy,](https://www.epa.gov/web-policies-and-procedures/epa-comment-policy#:~:text=In%20posting%20his%20or%20her,and%20free%2Dof%2Dcharge.) which will be periodically revised.
+This Code of Conduct applies to the [US-EPA-CAMD](https://github.com/US-EPA-CAMD) GitHub organization, its communications, events, and anyone participating in the US-EPA-CAMD GitHub community. Your use of our repositories means you accept and agree to abide by this Code of Conduct, and the [EPA Comment Policy,](https://www.epa.gov/web-policies-and-procedures/epa-comment-policy/) which will be periodically revised.
 
 ## Expectations of Visitors and Contributors
 We expect all visitors and contributors to the US-EPA-CAMD GitHub organization and its repositories to have a safe and engaging experience that is beneficial to our community. Members of our community have a diverse set of experiences and skillsets. As you engage our community, please ensure you are:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# US-EPA-CAMD Code of Conduct
+## Introduction
+We are committed to building a safe, friendly, and harassment-free culture for everyone. We pledge to interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Scope
+This Code of Conduct applies to the [US-EPA-CAMD](https://github.com/US-EPA-CAMD) GitHub organization, its communications, events, and anyone participating in the US-EPA-CAMD GitHub community. Your use of our repositories means you accept and agree to abide by this Code of Conduct, and the [EPA Comment Policy,](https://www.epa.gov/web-policies-and-procedures/epa-comment-policy#:~:text=In%20posting%20his%20or%20her,and%20free%2Dof%2Dcharge.) which will be periodically revised.
+
+## Expectations of Visitors and Contributors
+We expect all visitors and contributors to the US-EPA-CAMD GitHub organization and its repositories to have a safe and engaging experience that is beneficial to our community. Members of our community have a diverse set of experiences and skillsets. As you engage our community, please ensure you are:
+- Considerate: As an open source community, what you do will affect others. Ensure what you do is in the best interest of the project, and community at large.
+- Collaborative: The essence of open source is collaborative in nature. Be respectful of differing opinions and viewpoints.
+- Patient: Remember that open source is a culture change in government and while this repository is a testament to that change, change is occurring thanks to many in this community. Be patient if your question or issue is not answered right away. 
+- Be mindful: Be aware of your actions, and others' actions. Treat people with empathy, dignity, and respect - the way you want to be treated.
+- Use clear communication: We don’t all speak the same language. Further, written or typed words may lack the tone or body language necessary to interpret intent or meaning. If your words could have more than one meaning, take time to be clear with your words and remember to be kind.
+
+## Unacceptable Behavior
+Users have a reasonable expectation to engage in our community free from harassment. Harassment can include but is not limited to offensive verbal comments related to gender, age, sexual orientation, disability, physical appearance, race, religion, deliberate intimidation, disruption of talks or events. 
+Anything that is unlawful, objectionable, offensive, abusive, threatening, defamatory, obscene, hateful, inflammatory, profane, racially, sexually or religiously offensive is not permitted.
+
+## Enforcement
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, issues, and other contributions that are not aligned to this Code of Conduct.
+
+Unacceptable behavior from any community member, including those with decision-making authority, will not be tolerated. Anyone asked to cease unacceptable behavior is expected to comply immediately. If a community member engages in unacceptable behavior, the US-EPA-CAMD GitHub organization will take any action it deems appropriate, up to and including a temporary ban or permanent expulsion from the community without warning. This can include removal from email lists, team meetings, and repositories.
+
+## Attribution
+This Code of Conduct is adapted from the following sources:
+- [Contributor Covenant](https://www.contributor-covenant.org/)
+- [Technology Transformation Services (TTS) Code of Conduct](https://18f.gsa.gov/code-of-conduct/)
+- [Consumer Financial Protection Bureau (CFPB) Code of Conduct](https://github.com/cfpb/consumerfinance.gov/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Adding new code of conduct file:

This code of conduct is based off the draft EPA code of conduct that I obtained from Joe T.

I added an "Intro" section, improved readability across the entire document by cleaning up long or unclear sentences, and added some additional information from the referenced code of conducts from GSA/CFPB.

@ibarra-michelle @maheese @jthomp13 - please review this code of conduct and add comments if anything is unclear or should be modified.

Once approved, the code of conduct will be added to all of our repositories.

Thanks!
