### PR TITLE
release/v0.0-easey-ui

### DIFF
--- a/manifest.dev.yml
+++ b/manifest.dev.yml
@@ -12,4 +12,4 @@ applications:
     # health-check-type: http
     # health-check-http-endpoint: /
     routes:
-      - route: easey-dev.app.cloud.gov
+      - route: easey-dev.app.cloud.gov/portal

--- a/manifest.staging.yml
+++ b/manifest.staging.yml
@@ -12,4 +12,4 @@ applications:
     # health-check-type: http
     # health-check-http-endpoint: /
     routes:
-      - route: easey-stg.app.cloud.gov
+      - route: easey-stg.app.cloud.gov/portal

--- a/manifest.test.yml
+++ b/manifest.test.yml
@@ -12,4 +12,4 @@ applications:
     # health-check-type: http
     # health-check-http-endpoint: /
     routes:
-      - route: easey-tst.app.cloud.gov
+      - route: easey-tst.app.cloud.gov/portal


### PR DESCRIPTION
changing manifest routes to use /portal to address an issue with cloud.gov can manually map back to root after deployment